### PR TITLE
Use Simple.Fuzzy to search through files tree

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "NoRedInk/elm-simple-fuzzy": "1.0.2 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/keyboard": "1.0.1 <= v < 2.0.0"

--- a/src/Path.elm
+++ b/src/Path.elm
@@ -13,6 +13,7 @@ module Path
         , unroll
         )
 
+import Simple.Fuzzy as Fuzzy
 
 type alias File =
     { name : String
@@ -46,15 +47,7 @@ purgeHidden flag tree =
 
 
 entryFilter : String -> File -> Bool
-entryFilter pred file =
-    let
-        lowerSearch =
-            String.toLower pred
-
-        lowerName =
-            String.toLower file.name
-    in
-        String.contains lowerSearch lowerName
+entryFilter pred = (Fuzzy.match pred) << .name
 
 
 filterBy : String -> Tree -> Tree


### PR DESCRIPTION
Not knowing Elm I decided to give it a try and solve one of the issues I've created  (#3).

This MR imports [simple-fuzzy](http://package.elm-lang.org/packages/NoRedInk/elm-simple-fuzzy/1.0.2/Simple-Fuzzy) package and makes use of it in `Path.entryFilter()`